### PR TITLE
Fix/path bilding

### DIFF
--- a/include/filesystem/PathUtils.hpp
+++ b/include/filesystem/PathUtils.hpp
@@ -21,10 +21,8 @@ class PathUtils {
     //                              const std::string& location,
     //                              const std::string& request_path);
 
-    // Защита от ../
-    // static bool        isSafe(const std::string& path);
-
-    static std::string bildPathForDirectory(const std::string& path, const std::string& location);
+    static std::string bildPathForDirectory(const std::string& path,
+                                            const std::string& defaultFile);
     static std::string getContentType(const std::string& path);
 
    private:

--- a/include/filesystem/PathUtils.hpp
+++ b/include/filesystem/PathUtils.hpp
@@ -24,7 +24,7 @@ class PathUtils {
     // Защита от ../
     // static bool        isSafe(const std::string& path);
 
-    // Content-Type по расширению
+    static std::string bildPathForDirectory(const std::string& path, const std::string& location);
     static std::string getContentType(const std::string& path);
 
    private:

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -47,7 +47,7 @@ void ServerConfig::applyDefaults() {
     r.add_acceptedMethod("POST");
     add_route(r);
 
-		// hardcoded to make testing for 405 & 501 work correctly
+    // hardcoded to make testing for 405 & 501 work correctly
     RouteConfig method_not_allowed;
     method_not_allowed.url = "/method_not_allowed";
     method_not_allowed.rootDirectory = "www";
@@ -59,10 +59,6 @@ void ServerConfig::applyDefaults() {
 // Made const so it can be called on const ServerConfig& (e.g. in RequestValidator).
 // Returns const RouteConfig* because the caller should not mutate config data:
 const RouteConfig* ServerConfig::findMatchingLocation(std::string path) const {
-    // Deleting / ath the end of the path /photos/ → /photos
-    if (path.length() > 1 && path[path.length() - 1] == '/')
-        path = path.substr(0, path.length() - 1);
-
     const RouteConfig* best_match = NULL;
     size_t best_length = 0;
 

--- a/src/filesystem/PathUtils.cpp
+++ b/src/filesystem/PathUtils.cpp
@@ -41,7 +41,8 @@ std::string PathUtils::getContentType(const std::string& path) {
 std::string PathUtils::bildPathForDirectory(const std::string& path,
                                             const std::string& defaultFile) {
     std::string indexPath;
-    if (path[path.length() - 1] == '/') {
+    int pathLen = path.length();
+    if (pathLen > 0 && path[pathLen - 1] == '/') {
         indexPath = path + defaultFile;
     } else {
         indexPath = path + "/" + defaultFile;

--- a/src/filesystem/PathUtils.cpp
+++ b/src/filesystem/PathUtils.cpp
@@ -37,3 +37,13 @@ std::string PathUtils::getContentType(const std::string& path) {
     }
     return "application/octet-stream";
 }
+
+std::string PathUtils::bildPathForDirectory(const std::string& path, const std::string& location) {
+    std::string indexPath;
+    if (path[path.length() - 1] == '/') {
+        indexPath = path + location;
+    } else {
+        indexPath = path + "/" + location;
+    }
+    return indexPath;
+}

--- a/src/filesystem/PathUtils.cpp
+++ b/src/filesystem/PathUtils.cpp
@@ -38,12 +38,13 @@ std::string PathUtils::getContentType(const std::string& path) {
     return "application/octet-stream";
 }
 
-std::string PathUtils::bildPathForDirectory(const std::string& path, const std::string& location) {
+std::string PathUtils::bildPathForDirectory(const std::string& path,
+                                            const std::string& defaultFile) {
     std::string indexPath;
     if (path[path.length() - 1] == '/') {
-        indexPath = path + location;
+        indexPath = path + defaultFile;
     } else {
-        indexPath = path + "/" + location;
+        indexPath = path + "/" + defaultFile;
     }
     return indexPath;
 }

--- a/src/handler/ErrorHandler.cpp
+++ b/src/handler/ErrorHandler.cpp
@@ -28,7 +28,7 @@ std::string ErrorHandler::getCustomPage(int code) const {
     std::string body;
     int status = _fileService.readFile(it->second, body);
     if (status != HTTP_OK) {
-        LOG_WARNING("Incorrect path for custom error page: " + it->second + toString(code));
+        LOG_WARNING("Incorrect path for custom error page: " + it->second);
         return "";
     }
     return body;

--- a/src/handler/RequestHandler.cpp
+++ b/src/handler/RequestHandler.cpp
@@ -42,7 +42,7 @@ HttpResponse Handler::serveFile(const std::string& path) {
 HttpResponse Handler::handleDirectory(const std::string& path, const std::string& uri,
                                       const RouteConfig* _location) {
     struct stat info;
-    std::string indexPath = path + "/" + _location->defaultFile;
+    std::string indexPath = PathUtils::bildPathForDirectory(path, _location->defaultFile);
     LOG_DEBUG("Path to default file: " + indexPath);
     int status = _fileService.checkPath(indexPath, info);
     if (status == HTTP_OK && S_ISREG(info.st_mode)) {

--- a/unit_tests/tests_filesystem.cpp
+++ b/unit_tests/tests_filesystem.cpp
@@ -96,3 +96,17 @@ TEST_CASE("PathUtils::getContentType handles path with dots", "[PathUtils]") {
     REQUIRE(PathUtils::getContentType("./my.site/index.html") == "text/html");
     REQUIRE(PathUtils::getContentType("./my.site/photo.jpg") == "image/jpeg");
 }
+
+TEST_CASE("PathUtils::buildPathForDirectory returns correct path", "[PathUtils]") {
+    SECTION("Path ending without /") {
+        std::string path = "./www/upload";
+        std::string defaultFile = "index.html";
+        REQUIRE(PathUtils::bildPathForDirectory(path, defaultFile) == "./www/upload/index.html");
+    }
+
+    SECTION("Path ending with /") {
+        std::string path = "./www/upload/";
+        std::string defaultFile = "index.html";
+        REQUIRE(PathUtils::bildPathForDirectory(path, defaultFile) == "./www/upload/index.html");
+    }
+}


### PR DESCRIPTION
This update introduces a small refactoring and fixes around path handling and logging behavior.

### Changes

1. Refactored path construction logic to prevent duplicate slashes (//) when building path for `defaultFile` for GET directory requests.

This logic has been extracted into a dedicated utility function in PathUtils class.
Added unit tests to validate correct path joining behavior and ensure no double-slash cases occur.

2. Fixed logging for error paths to correctly display resolved filesystem paths.

### Known limitation

Autoindex handling for directories without a trailing slash is not yet fixed. This requires redirect handling and will be addressed in a follow-up change.